### PR TITLE
新增支持假删除

### DIFF
--- a/src/main/java/apijson/framework/APIJSONSQLConfig.java
+++ b/src/main/java/apijson/framework/APIJSONSQLConfig.java
@@ -20,6 +20,7 @@ import static apijson.framework.APIJSONConstant.USER_;
 import static apijson.framework.APIJSONConstant.USER_ID;
 
 import java.util.List;
+import java.util.Map;
 
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
@@ -253,5 +254,13 @@ public class APIJSONSQLConfig extends AbstractSQLConfig {
 		return newSQLConfig(method, table, alias, request, joinList, isProcedure, SIMPLE_CALLBACK);
 	}
 
+	@Override
+	public boolean isFakeDelete() {
+		return false;
+	}
 
+	@Override
+	public void onFakeDelete(Map<String, Object> map) {
+		
+	}
 }


### PR DESCRIPTION
1、access表新增字段
`deletedKey` varchar(255) DEFAULT NULL COMMENT '假删除字段名',
 `deletedValue` int(11) DEFAULT NULL COMMENT '假删除, 删除状态,字段值',
2、DemoSQLConfig
实现isFakeDelete()、onFakeDelete()方法
isFakeDelete()  //是否启用假删除
onFakeDelete() //​假删除需要更新的其他字段，比如：删除时间 deletedTime 之类的 
3、业务侧
如果启用假删除，不要忘记数据库表添加 deletedKey、onFakeDelete() 字段
比如：
![image](https://user-images.githubusercontent.com/12228225/210925321-3f79618a-3c39-4812-82e8-1b689feaf862.png)
